### PR TITLE
Parameterized version of spinnaker components, imported spinnaker-local.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ a pipeline.
 1. Once instance provisioning is complete get the name of your Spinnaker and Jenkins instances by
    running:
 
-        export SPINNAKER_VM=$(gcloud compute instances list --regexp ".*spinnaker.*" --uri)
-        export JENKINS_VM=$(gcloud compute instances list --regexp ".*jenkins.*" --uri)
+        export SPINNAKER_VM=$(gcloud compute instances list --regexp "${DEPLOYMENT_NAME}-spinnaker.+" --uri)
+        export JENKINS_VM=$(gcloud compute instances list --regexp "${DEPLOYMENT_NAME}-jenkins.+" --uri)
 
 1. Creating an SSH tunnel to your Spinnaker instance as follows:
 
         gcloud compute ssh ${SPINNAKER_VM} -- -L 9000:localhost:9000 -L8080:$(basename $JENKINS_VM):8080
 
-1. Access the Spinnaker and Jenkins UIs respectively by visiting the following web address:
+1. After a few minutes, you can access the Spinnaker and Jenkins UIs respectively by visiting the following web address:
 
         http://localhost:9000
         http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -13,24 +13,35 @@ a pipeline.
 
 1. Download the repository.
 1. Create the deployment:
-    
-        gcloud deployment-manager deployments create --config config.jinja [DEPLOYMENT_NAME] --properties jenkinsPassword:[YOUR_PASSWORD]
 
-1. Once instance provisioning is complete get the name of your Spinnaker instance by
+        export GOOGLE_PROJECT=$(gcloud config get-value project)
+        export DEPLOYMENT_NAME="${USER}-test1"
+        export JENKINS_PASSWORD=$(openssl rand -base64 15)
+        gcloud deployment-manager deployments create --config config.jinja ${DEPLOYMENT_NAME} --properties jenkinsPassword:${JENKINS_PASSWORD}
+
+1. Once instance provisioning is complete get the name of your Spinnaker and Jenkins instances by
    running:
 
-        gcloud compute instances list | grep spinnaker
-       
+        export SPINNAKER_VM=$(gcloud compute instances list --regexp ".*spinnaker.*" --uri)
+        export JENKINS_VM=$(gcloud compute instances list --regexp ".*jenkins.*" --uri)
+
 1. Creating an SSH tunnel to your Spinnaker instance as follows:
 
-        gcloud compute ssh [DEPLOYMENT_NAME]-spinnaker-ogo8 --zone us-west1-a -- -L 9000:localhost:9000 -L8084:localhost:8084
+        gcloud compute ssh ${SPINNAKER_VM} -- -L 9000:localhost:9000 -L8080:$(basename $JENKINS_VM):8080
 
-1. Access the UI by visiting the following web address:
+1. Access the Spinnaker and Jenkins UIs respectively by visiting the following web address:
 
         http://localhost:9000
+        http://localhost:8080
 
 ## Teardown
 
+1. Stop the front50 service then delete the GCS objects and bucket:
+
+       gcloud compute ssh ${SPINNAKER_VM} -- sudo service front50 stop
+       gsutil rm -r gs://spinnaker-${GOOGLE_PROJECT}-${DEPLOYMENT_NAME}/front50
+       gsutil rb gs://spinnaker-${GOOGLE_PROJECT}-${DEPLOYMENT_NAME}
+
 1. Delete the deployment by running:
 
-       gcloud deployment-manager deployments delete [DEPLOYMENT_NAME]
+       gcloud deployment-manager deployments delete ${DEPLOYMENT_NAME}

--- a/config.jinja.schema
+++ b/config.jinja.schema
@@ -32,6 +32,8 @@ imports:
   path: templates/redis.jinja
 - name: spinnaker.sh
   path: scripts/spinnaker.sh
+- name: spinnaker-local.yml
+  path: config/spinnaker-local.yml
 - name: redis.sh
   path: scripts/redis.sh
 - name: jenkins.sh

--- a/config.jinja.schema
+++ b/config.jinja.schema
@@ -34,6 +34,8 @@ imports:
   path: scripts/spinnaker.sh
 - name: spinnaker-local.yml
   path: config/spinnaker-local.yml
+- name: gce-ansible.json
+  path: config/gce-ansible.json
 - name: redis.sh
   path: scripts/redis.sh
 - name: jenkins.sh

--- a/config/gce-ansible.json
+++ b/config/gce-ansible.json
@@ -10,6 +10,7 @@
     "appversion": "",
     "build_host": "",
     "repository": "",
+    "repository_hash": "master",
     "package_type": "",
     "packages": "",
     "upgrade": "",
@@ -32,10 +33,12 @@
   "provisioners": [
     {
      "type": "shell",
-     "inline": ["sudo apt-get update",
-                "sudo apt-get install -y ansible git",
-                "sudo git clone {{user `repository`}} /opt/deploy",
-                "sudo ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook -i 'localhost,' /opt/deploy/bake.yml"]
+     "inline": ["sudo apt-add-repository -y ppa:ansible/ansible",
+                "sudo apt-get update",
+                "sudo apt-get install -y ansible=2.3.0.0-1ppa~xenial git=1:2.7.4-0ubuntu1",
+                "sudo git clone {{user `repository`}} /opt/go/src/deploy",
+                "cd /opt/go/src/deploy && sudo git checkout {{user `repository_hash`}}",
+                "sudo ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook -i 'localhost,' bake.yml"]
     }
   ]
 }

--- a/config/gce-ansible.json
+++ b/config/gce-ansible.json
@@ -1,0 +1,41 @@
+{
+  "variables": {
+    "gce_project_id": null,
+    "gce_account_file": "",
+    "gce_zone": null,
+    "gce_network": null,
+    "gce_source_image": null,
+    "gce_target_image": null,
+    "gce_use_internal_ip": "false",
+    "appversion": "",
+    "build_host": "",
+    "repository": "",
+    "package_type": "",
+    "packages": "",
+    "upgrade": "",
+    "configDir": null
+  },
+  "builders": [{
+    "type": "googlecompute",
+    "project_id": "{{user `gce_project_id`}}",
+    "account_file": "{{user `gce_account_file`}}",
+    "zone": "{{user `gce_zone`}}",
+    "network": "{{user `gce_network`}}",
+    "state_timeout": "15m",
+    "ssh_username": "packerio",
+    "ssh_pty": true,
+    "source_image": "{{user `gce_source_image`}}",
+    "image_name": "{{user `gce_target_image`}}",
+    "use_internal_ip": "{{user `gce_use_internal_ip`}}",
+    "image_description": "appversion: {{user `appversion`}}, build_host: {{user `build_host`}}, build_info_url: {{user `build_info_url`}}"
+  }],
+  "provisioners": [
+    {
+     "type": "shell",
+     "inline": ["sudo apt-get update",
+                "sudo apt-get install -y ansible git",
+                "sudo git clone {{user `repository`}} /opt/deploy",
+                "sudo ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook -i 'localhost,' /opt/deploy/bake.yml"]
+    }
+  ]
+}

--- a/config/spinnaker-local.yml
+++ b/config/spinnaker-local.yml
@@ -268,6 +268,9 @@ services:
     # They typically live in rosco's config/packer directory.
     configDir: /opt/rosco/config/packer
 
+  bakery:
+    allowMissingPackageInstallation: true
+
   fiat:
     enabled: false
 

--- a/config/spinnaker-local.yml
+++ b/config/spinnaker-local.yml
@@ -1,0 +1,332 @@
+# This file is intended to override the default configuration in the
+# spinnaker.yml file while providing guidance on the mostly likely
+# configuration parameters to be changed.
+#
+# In order for Spinnaker to discover it, it must be copied to a file named
+# "spinnaker-local.yml" and placed in /opt/spinnaker/config
+# (or when running from source code, in the $HOME/.spinnaker directory.)
+#
+# A better practice could be to create the spinnaker-local.yml file by
+# hand with only the particular attributes that you want to override
+# and use the spinnaker.yml file as your guide since it is spinnaker.yml
+# that we are overriding here in the first place.
+
+global:
+  spinnaker:
+    timezone: 'America/Los_Angeles'
+
+providers:
+  # See http://www.spinnaker.io/v1.0/docs/target-deployment-setup
+  # for general information about configuring spinnaker platform providers.
+
+  # Each of the following providers can be enabled independent of all other
+  # providers unless otherwise noted.
+  #
+  # Each provider can be enabled by setting its 'enabled' attribute to true.
+  # As a rule of thumb, each provider defines a 'primaryCredentials' block
+  # that configures a default account for Spinnaker to use on that platform.
+  # If additional accounts are desired, then add those accounts to a
+  # custom clouddriver-local.yml file and consult clouddriver.yml for more
+  # information on what to add there.
+
+  aws:
+    # For more information on configuring Amazon Web Services (aws), see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-amazon-web-services-setup
+
+    enabled: ${SPINNAKER_AWS_ENABLED:false}
+    defaultRegion: ${SPINNAKER_AWS_DEFAULT_REGION:us-west-2}
+    defaultIAMRole: BaseIAMRole
+    primaryCredentials:
+      name: my-aws-account
+      # Store actual credentials in $HOME/.aws/credentials. See spinnaker.yml
+      # for more information, including alternatives.
+
+    # {{name}} will be interpolated with the aws account name (e.g. "my-aws-account-keypair").
+    defaultKeyPairTemplate: "{{name}}-keypair"
+
+  azure:
+    # For more information on configuring Microsoft Azure (azure), see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-azure-cloud-platform-setup
+
+    enabled: ${SPINNAKER_AZURE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_AZURE_DEFAULT_REGION:westus}
+    primaryCredentials:
+      name: my-azure-account
+
+      # To set Azure credentials, enter your Azure supscription values for:
+      # clientId, appKey, tenantId, subscriptionId, and objectId.
+      clientId:
+      appKey:
+      tenantId:
+      subscriptionId:
+      objectId:
+      packerResourceGroup:
+      packerStorageAccount:
+      defaultResourceGroup:
+      defaultKeyVault:
+
+  google:
+    # For more information on configuring Google Cloud Platform (google), see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-google-cloud-platform-setup
+
+    enabled: ${SPINNAKER_GOOGLE_ENABLED:false}
+    defaultRegion: ${SPINNAKER_GOOGLE_DEFAULT_REGION:us-central1}
+    defaultZone: ${SPINNAKER_GOOGLE_DEFAULT_ZONE:us-central1-f}
+
+    primaryCredentials:
+      name: my-google-account
+      # The project is the Google Project ID for the project to manage with
+      # Spinnaker.
+      # The jsonPath is a path to the JSON service credentials downloaded
+      # from the Google Developer's Console.
+      project: ${SPINNAKER_GOOGLE_PROJECT_ID:}
+      jsonPath: ${SPINNAKER_GOOGLE_PROJECT_CREDENTIALS_PATH:}
+      consul:
+        enabled: ${SPINNAKER_GOOGLE_CONSUL_ENABLED:false}
+
+  cf:
+    # For more information on configuring Cloud Foundry (cf) support, see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-cloud-foundry-platform-setup
+
+    enabled: false
+    defaultOrg: spinnaker-cf-org
+    defaultSpace: spinnaker-cf-space
+
+    primaryCredentials:
+      name: my-cf-account
+      api: my-cf-api-uri
+      console: my-cf-console-base-url
+      # Either uncomment and plugin credentials here, or supply as
+      # environment variables for maximum security.
+      # account:
+      #   name: my-cf-username
+      #   password: my-cf-password
+
+  kubernetes:
+    # For more information on configuring Kubernetes clusters (kubernetes), see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-setup#section-kubernetes-cluster-setup
+
+    # NOTE: enabling kubernetes also requires enabling dockerRegistry.
+    enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
+    primaryCredentials:
+      # These credentials use authentication information at ~/.kube/config
+      # by default.
+      name: my-kubernetes-account
+      dockerRegistryAccount: ${providers.dockerRegistry.primaryCredentials.name}
+
+  dockerRegistry:
+    # For more information on configuring Docker registries, see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-configuration#section-docker-registry
+
+    # NOTE: Enabling dockerRegistry is independent of other providers.
+    # However, for convienience, we tie docker and kubernetes together
+    # since kubernetes (and only kubernetes) depends on this docker provider
+    # configuration.
+    enabled: ${SPINNAKER_KUBERNETES_ENABLED:false}
+
+    primaryCredentials:
+      name: my-docker-registry
+      address: ${SPINNAKER_DOCKER_REGISTRY:https://index.docker.io/}
+      repository: ${SPINNAKER_DOCKER_REPOSITORY:}
+      username: ${SPINNAKER_DOCKER_USERNAME:}
+      # A path to a plain text file containing the user's password
+      passwordFile: ${SPINNAKER_DOCKER_PASSWORD_FILE:}
+
+  openstack:
+    # For more information on configuring Openstack clusters, see
+    # http://www.spinnaker.io/v1.0/docs/target-deployment-configuration#section-openstack
+
+    enabled: ${SPINNAKER_OPENSTACK_ENABLED:false}
+    primaryCredentials:
+      name: my-openstack-account
+      authUrl: ${OS_AUTH_URL}
+      username: ${OS_USERNAME}
+      password: ${OS_PASSWORD}
+      projectName: ${OS_PROJECT_NAME}
+      regions: ${OS_REGION_NAME:RegionOne}
+
+  appengine:
+    enabled: ${SPINNAKER_APPENGINE_ENABLED:false}
+
+    primaryCredentials:
+      name: my-appengine-account
+      # The project is the Google Project ID for the project to manage with
+      # Spinnaker.
+      project: ${SPINNAKER_APPENGINE_PROJECT_ID:}
+      # The jsonPath is a path to the JSON service credentials downloaded
+      # from the Google Developer's Console.
+      jsonPath: ${SPINNAKER_APPENGINE_PROJECT_CREDENTIALS_PATH:}
+      # The path and password to an SSH private key to be used when connecting with
+      # a remote git repository over SSH (optional).
+      sshPrivateKeyFilePath: ${SPINNAKER_APPENGINE_PRIVATE_KEY_FILE_PATH:}
+      sshPrivateKeyPassphrase: ${SPINNAKER_APPENGINE_PRIVATE_KEY_PASSPHRASE:}
+      # The username and password to be used when connecting with a remote git repository over HTTPS (optional).
+      gitHttpsUsername: ${SPINNAKER_APPENGINE_GIT_HTTPS_USERNAME:}
+      gitHttpsPassword: ${SPINNAKER_APPENGINE_GIT_HTTPS_PASSWORD:}
+      # The OAuth token provided by Github to be used when connecting with a remote git repository over HTTPS (optional).
+      # See https://help.github.com/articles/creating-an-access-token-for-command-line-use for more information.
+      githubOAuthAccessToken: ${SPINNAKER_APPENGINE_GITHUB_OAUTH_ACCESS_TOKEN:}
+
+services:
+  default:
+    # These defaults can be modified to change all the spinnaker subsystems
+    # (clouddriver, gate, etc) at once, but not external systems (jenkins, etc).
+    # Individual systems can still be overridden using their own section entry
+    # directly under 'services'.
+    protocol: http    # Assume all spinnaker subsystems are using http
+    host: localhost   # Assume all spinnaker subsystems are on localhost
+    primaryAccountName: ${providers.google.primaryCredentials.name}
+
+  redis:
+    # If you are using a remote redis server, you can set the host here.
+    # If the remote server is on a different port or url, you can add
+    # a "port" or "baseUrl" field here instead.
+    host: ${SPINNAKER_REDIS_HOST:localhost}
+
+  cassandra:
+    # If you are using a remote cassandra server, you can set the host here.
+    # If the remote server is on a different port or url, you can add
+    # a "port" or "baseUrl" field here instead. You may also need to set
+    # the cluster name. See the main spinnaker.yml file for more attributes.
+    host: localhost
+
+  docker:
+    # This target repository is used by the bakery to publish baked docker images.
+    # Do not include http://.
+    targetRepository: # Optional, but expected in spinnaker-local.yml if specified.
+
+  jenkins:
+    # If you are integrating Jenkins, set its location here using the baseUrl
+    # field and provide the username/password credentials.
+    # You must also enable the "igor" service listed separately.
+    #
+    # If you have multiple jenkins servers, you will need to list
+    # them in an igor-local.yml. See jenkins.masters in config/igor.yml.
+    #
+    # Note that jenkins is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    enabled: ${services.igor.enabled:false}
+    defaultMaster:
+      name: Jenkins # The display name for this server
+      baseUrl: ${SPINNAKER_JENKINS_BASEURL:}
+      username: ${SPINNAKER_JENKINS_USER:}
+      password: ${SPINNAKER_JENKINS_PASSWORD:}
+
+  travis:
+    # If you are integrating Travis, set its location here using the baseUrl
+    # and adress fields and provide the githubToken for authentication.
+    # You must also enable the "igor" service listed separately.
+    #
+    # If you have multiple travis servers, you will need to list
+    # them in an igor-local.yml. See travis.masters in config/igor.yml.
+    #
+    # Note that travis is not installed with Spinnaker so you must obtain this
+    # on your own if you are interested.
+    enabled: false
+    defaultMaster:
+      name: ci # The display name for this server. Gets prefixed with "travis-"
+      baseUrl: https://travis-ci.com
+      address: https://api.travis-ci.org
+      githubToken: # GitHub scopes currently required by Travis is required.
+
+
+  spectator:
+    webEndpoint:
+      enabled: true
+
+  stackdriver:
+    enabled: false
+
+  clouddriver:
+    aws:
+      udf:
+        # Controls whether UserDataProviders are used to populate user data of
+        # new server groups. If false, user data is copied over from ancestor
+        # server groups on both CopyLastAsgAtomicOperation and
+        # ModifyAsgLaunchConfigurationOperation (only if no user data is
+        # provided on the given request).
+        enabled: true
+
+  igor:
+    # If you are integrating Jenkins then you must also enable Spinnaker's
+    # "igor" subsystem.
+    enabled: ${SPINNAKER_JENKINS_ENABLED:false}
+
+  deck:
+    # Frontend configuration.
+    # If you are proxying Spinnaker behind a single host, you may want to
+    # override these values. Remember to run `reconfigure_spinnaker.sh` after.
+    #baseUrl: http://spinnaker.mydomain.com
+    gateUrl: ${services.deck.baseUrl}/gate
+    #bakeryUrl: ${services.deck.baseUrl}/rosco
+    auth:
+      enabled: false
+
+  rosco:
+    # You need to provide the fully-qualified path to the directory containing
+    # the packer templates.
+    # They typically live in rosco's config/packer directory.
+    configDir: /opt/rosco/config/packer
+
+  fiat:
+    enabled: false
+
+  front50:
+    cassandra:
+      enabled: false
+    redis:
+      enabled: false
+
+    # To use a cloud storage bucket on Amazon S3 or Google Cloud Storage instead
+    # of cassandra, set the storage_bucket, disable cassandra, and enable one of
+    # the service providers.
+    storage_bucket: ${SPINNAKER_DEFAULT_STORAGE_BUCKET:}
+    gcs:
+      enabled: true
+    s3:
+      enabled: false
+
+    # To use an Azure storage account instead of Cassandra:
+    # Disable Cassandra above, enable azs, and set the storage account name and key
+    azs:
+      enabled: false
+      storageAccountName:
+      storageAccountKey:
+      storageContainerName: front50
+
+  echo:
+    # Persistence mechanism to use
+    cassandra:
+      enabled: false
+    inMemory:
+      enabled: true
+
+    cron:
+      # Allow pipeline triggers to run periodically via cron expressions.
+      enabled: true
+
+    notifications:
+      # The following blocks can enable Spinnaker to send notifications
+      # using the corresponding mechanism.
+      # See http://www.spinnaker.io/docs/notifications-and-events-guide
+      # for more information.
+      mail:
+        enabled: false
+        host: # the smtp host
+        fromAddress: #the address for which emails are sent from
+      hipchat:
+        enabled: false
+        url: # the hipchat server to connect to
+        token: #the hipchat auth token
+        botName: # the username of the bot
+      sms:
+        enabled: false
+        account: # twilio account id
+        token: # twilio auth token
+        from: # phone number by which sms messages are sent
+      slack:
+        # See https://api.slack.com/bot-users for details about using bots
+        # and how to create your own bot user.
+        enabled: false
+        token: # the API token for the bot
+        botName: # the username of the bot

--- a/scripts/jenkins.sh
+++ b/scripts/jenkins.sh
@@ -78,6 +78,16 @@ cat > /var/lib/jenkins/config.xml <<EOF
 </hudson>
 EOF
 
+# Install initial plugins
+JENKINS_PLUGIN_DIR=/var/lib/jenkins/plugins
+mkdir -p ${JENKINS_PLUGIN_DIR}
+PLUGINS="structs/1.6/structs.hpi workflow-step-api/1.14.2/workflow-step-api.hpi workflow-scm-step/1.14.2/workflow-scm-step.hpi git-client/2.4.1/git-client.hpi scm-api/2.1.1/scm-api.hpi git/3.2.0/git.hpi"
+JENKINS_PLUGIN_URL="http://updates.jenkins-ci.org/download/plugins"
+for p in ${PLUGINS}; do
+  curl --retry 3 --retry-delay 5 -sSL -f ${JENKINS_PLUGIN_URL}/${p} -o ${JENKINS_PLUGIN_DIR}/$(basename ${p})
+done
+chown -R jenkins:jenkins ${JENKINS_PLUGIN_DIR}
+
 # Create spinnaker job
 mkdir -p /var/lib/jenkins/jobs/runSpinnakerScript
 cat > /var/lib/jenkins/jobs/runSpinnakerScript/config.xml <<EOF

--- a/scripts/spinnaker.sh
+++ b/scripts/spinnaker.sh
@@ -26,6 +26,17 @@ JENKINS_IP=`metadata_value "instance/attributes/jenkinsIP"`
 JENKINS_PASSWORD=`metadata_value "instance/attributes/jenkinsPassword"`
 REDIS_IP=`metadata_value "instance/attributes/redisIP"`
 
+PACKER_VERSION=`metadata_value "instance/attributes/packerVersion"`
+CLOUDDRIVER_VERSION=`metadata_value "instance/attributes/clouddriverVersion"`
+DECK_VERSION=`metadata_value "instance/attributes/deckVersion"`
+ECHO_VERSION=`metadata_value "instance/attributes/echoVersion"`
+FRONT50_VERSION=`metadata_value "instance/attributes/front50Version"`
+GATE_VERSION=`metadata_value "instance/attributes/gateVersion"`
+IGOR_VERSION=`metadata_value "instance/attributes/igorVersion"`
+ORCA_VERSION=`metadata_value "instance/attributes/orcaVersion"`
+ROSCO_VERSION=`metadata_value "instance/attributes/roscoVersion"`
+SPINNAKER_VERSION=`metadata_value "instance/attributes/spinnakerVersion"`
+
 curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
 bash install-logging-agent.sh
 curl -sSO https://repo.stackdriver.com/stack-install.sh
@@ -35,10 +46,16 @@ echo "deb https://dl.bintray.com/spinnaker/debians trusty spinnaker" > /etc/apt/
 curl -s -f "https://bintray.com/user/downloadSubjectPublicKey?username=spinnaker" | apt-key add -
 add-apt-repository -y ppa:openjdk-r/ppa
 apt-get update
-apt-get install -y openjdk-8-jdk spinnaker-clouddriver \
-                   spinnaker-deck spinnaker-echo spinnaker-front50 \
-                   spinnaker-gate spinnaker-igor spinnaker-orca \
-                   spinnaker-rosco spinnaker unzip
+apt-get install -y openjdk-8-jdk unzip \
+                   spinnaker-clouddriver=${CLOUDDRIVER_VERSION} \
+                   spinnaker-deck=${DECK_VERSION} \
+                   spinnaker-echo=${ECHO_VERSION} \
+                   spinnaker-front50=${FRONT50_VERSION} \
+                   spinnaker-gate=${GATE_VERSION} \
+                   spinnaker-igor=${IGOR_VERSION} \
+                   spinnaker-orca=${ORCA_VERSION} \
+                   spinnaker-rosco=${ROSCO_VERSION} \
+                   spinnaker=${SPINNAKER_VERSION}
 
 # Configure Web Server for Gate
 echo "Listen 0.0.0.0:9000" >> /etc/apache2/ports.conf
@@ -48,8 +65,8 @@ service apache2 restart
 # Install Packer
 mkdir -p /tmp/packer
 pushd /tmp/packer
-  curl -s -L -O https://releases.hashicorp.com/packer/0.12.2/packer_0.12.2_linux_amd64.zip
-  unzip -u -o -q packer_0.12.2_linux_amd64.zip -d /usr/bin
+  curl -s -L -O https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
+  unzip -u -o -q packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/bin
 popd
 rm -rf /tmp/packer
 cat > /etc/default/spinnaker <<EOF
@@ -74,7 +91,7 @@ script:
   job: runSpinnakerScript
 EOF
 
-wget https://gist.githubusercontent.com/viglesiasce/fa9806d22cb7d9d92761b27693904a11/raw/spinnaker-local.yml -O /opt/spinnaker/config/spinnaker-local.yml
+metadata_value "instance/attributes/spinnakerLocal" > /opt/spinnaker/config/spinnaker-local.yml
 
 /opt/spinnaker/bin/reconfigure_spinnaker.sh
 /opt/spinnaker/install/change_cassandra.sh --echo=inMemory --front50=gcs --change_defaults=true --change_local=false

--- a/scripts/spinnaker.sh
+++ b/scripts/spinnaker.sh
@@ -91,6 +91,8 @@ script:
   job: runSpinnakerScript
 EOF
 
+metadata_value "instance/attributes/gceAnsible" > /opt/rosco/config/packer/gce-ansible.json
+
 metadata_value "instance/attributes/spinnakerLocal" > /opt/spinnaker/config/spinnaker-local.yml
 
 /opt/spinnaker/bin/reconfigure_spinnaker.sh

--- a/templates/network.jinja
+++ b/templates/network.jinja
@@ -47,7 +47,6 @@ resources:
       - spinnaker-vm
     targetTags:
       - redis-vm
-      - allow-ssh
 - type: compute.v1.firewall
   name: jenkins-fw
   properties:
@@ -55,7 +54,7 @@ resources:
      network: $(ref.{{ env["deployment"] }}-spinnaker-network.selfLink)
      allowed:
      - IPProtocol: tcp
-       ports: ["80"]
+       ports: ["80","8080"]
      sourceTags:
      - spinnaker-vm
      targetTags:

--- a/templates/network.jinja
+++ b/templates/network.jinja
@@ -83,3 +83,40 @@ resources:
     - "130.211.0.0/22"
     targetTags:
     - spinnaker-vm
+- type: compute.v1.globalForwardingRule
+  name: {{ env["deployment"] }}-spinnaker-api-lb
+  properties:
+    IPProtocol: TCP
+    portRange: 80
+    target: $(ref.{{ env["deployment"] }}-spinnaker-api-targetproxy.selfLink)
+- type: compute.v1.targetHttpProxy
+  name: {{ env["deployment"] }}-spinnaker-api-targetproxy
+  properties:
+    urlMap: $(ref.{{ env["deployment"] }}-spinnaker-api.selfLink)
+- type: compute.v1.urlMap
+  name: {{ env["deployment"] }}-spinnaker-api
+  properties:
+    defaultService: $(ref.null-backend.selfLink)
+    hostRules:
+      - hosts: ["*"]
+        pathMatcher: pathmap
+    pathMatchers:
+      - name: pathmap
+        defaultService: $(ref.null-backend.selfLink)
+        pathRules:
+          - paths: ["/gate/webhooks/git/github", "/gate/webhooks/git/github/*"]
+            service: $(ref.{{ env["deployment"] }}-spinnaker-api-backend.selfLink)
+- type: compute.v1.backendService
+  name: null-backend
+  properties:
+    backends: []
+    healthChecks: [ $(ref.{{ env["deployment"] }}-spinnaker-hc.selfLink) ]
+- type: compute.v1.backendService
+  name: {{ env["deployment"] }}-spinnaker-api-backend
+  properties:
+    port: 9000
+    portName: "api"
+    backends:
+      - name: spinnaker-api
+        group: $(ref.{{ env["deployment"] }}-spinnaker-ig.instanceGroup)
+    healthChecks: [ $(ref.{{ env["deployment"] }}-spinnaker-hc.selfLink) ]

--- a/templates/redis.jinja
+++ b/templates/redis.jinja
@@ -34,6 +34,7 @@ resources:
         tags:
           items:
             - redis-vm
+            - allow-ssh
         networkInterfaces:
         - network: $(ref.{{ env["deployment"] }}-spinnaker-network.selfLink)
           subnetwork: $(ref.{{ env["deployment"] }}-spinnaker-subnetwork.selfLink)

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -27,7 +27,7 @@ resources:
     autoHealingPolicies:
     - healthCheck: $(ref.{{ env["deployment"] }}-spinnaker-hc.selfLink)
       initialDelaySec: 300
-- name: {{ env["deployment"] }}-spinnaker-bucket
+- name: spinnaker-{{ env["project"] }}-{{ env["deployment"] }}
   type: storage.v1.bucket
   properties:
     name: spinnaker-{{ env["project"] }}-{{ env["deployment"] }}

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -78,6 +78,29 @@ resources:
             value: {{ properties["jenkinsPassword"] }}
           - key: redisIP
             value: {{ properties["redisIP"] }}
+          - key: packerVersion
+            value: {{ properties["packerVersion"] }}
+          - key: clouddriverVersion
+            value: {{ properties["clouddriverVersion"] }}
+          - key: deckVersion
+            value: {{ properties["deckVersion"] }}
+          - key: echoVersion
+            value: {{ properties["echoVersion"] }}
+          - key: front50Version
+            value: {{ properties["front50Version"] }}
+          - key: gateVersion
+            value: {{ properties["gateVersion"] }}
+          - key: igorVersion
+            value: {{ properties["igorVersion"] }}
+          - key: orcaVersion
+            value: {{ properties["orcaVersion"] }}
+          - key: roscoVersion
+            value: {{ properties["roscoVersion"] }}
+          - key: spinnakerVersion
+            value: {{ properties["spinnakerVersion"] }}
+          - key: spinnakerLocal
+            value: |
+               {{ imports['spinnaker-local.yml']| indent(15) }}
           - key: startup-script
             value: |
                {{ imports['spinnaker.sh']| indent(15) }}

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -101,6 +101,9 @@ resources:
           - key: spinnakerLocal
             value: |
                {{ imports['spinnaker-local.yml']| indent(15) }}
+          - key: gceAnsible
+            value: |
+               {{ imports['gce-ansible.json']| indent(15) }}
           - key: startup-script
             value: |
                {{ imports['spinnaker.sh']| indent(15) }}

--- a/templates/spinnaker.jinja.schema
+++ b/templates/spinnaker.jinja.schema
@@ -29,11 +29,11 @@ properties:
   clouddriverVersion:
     type: string
     description: "Version of clouddriver"
-    default: "1.581.0"
+    default: "1.590.0"
   deckVersion:
     type: string
     description: "Version of deck"
-    default: "2.1063.0"
+    default: "2.1071.0"
   echoVersion:
     type: string
     description: "Version of echo"
@@ -45,7 +45,7 @@ properties:
   gateVersion:
     type: string
     description: "Version of gate"
-    default: "3.22.0"
+    default: "3.28.0"
   igorVersion:
     type: string
     description: "Version of igor"
@@ -53,7 +53,7 @@ properties:
   orcaVersion:
     type: string
     description: "Version of orca"
-    default: "1.381.0"
+    default: "1.387.0"
   roscoVersion:
     type: string
     description: "Version of rosco"
@@ -61,4 +61,4 @@ properties:
   spinnakerVersion:
     type: string
     description: "Version of spinnaker"
-    default: "0.78.0"
+    default: "0.79.0"

--- a/templates/spinnaker.jinja.schema
+++ b/templates/spinnaker.jinja.schema
@@ -1,0 +1,64 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  title: Spinnaker
+  author: Dan Isla <disla@google.com>
+  description: Runs Spinnaker
+  version: 1.0
+
+imports:
+- path: spinnaker.jinja
+
+properties:
+  packerVersion:
+    type: string
+    description: "Version of packer"
+    default: "1.0.0"
+  clouddriverVersion:
+    type: string
+    description: "Version of clouddriver"
+    default: "1.581.0"
+  deckVersion:
+    type: string
+    description: "Version of deck"
+    default: "2.1063.0"
+  echoVersion:
+    type: string
+    description: "Version of echo"
+    default: "1.132.0"
+  front50Version:
+    type: string
+    description: "Version of front50"
+    default: "1.90.0"
+  gateVersion:
+    type: string
+    description: "Version of gate"
+    default: "3.22.0"
+  igorVersion:
+    type: string
+    description: "Version of igor"
+    default: "1.65.0"
+  orcaVersion:
+    type: string
+    description: "Version of orca"
+    default: "1.381.0"
+  roscoVersion:
+    type: string
+    description: "Version of rosco"
+    default: "0.93.0"
+  spinnakerVersion:
+    type: string
+    description: "Version of spinnaker"
+    default: "0.78.0"


### PR DESCRIPTION
Misc improvements and fixes to get the latest version of spinnaker to work:

- Moved reference from `spinnaker-local.yml` file from gist into the repo, loaded via metadata.
- Fixes to make `deck` work with apache proxy in `spinnaker-local.yml`: `services.deck.gateUrl`.
- To prevent version drift, versions of all spanner components are now parameterized in the deployment template, see `templates/spinnaker.jinja.schema`
- Added http proxy for only the Github Webhook endpoint: `/gate/webhooks/git/github`