### PR TITLE
Compatibility with Cloud Shell. Moved deck to port 8081

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ a pipeline.
 
 1. Creating an SSH tunnel to your Spinnaker instance as follows:
 
-        gcloud compute ssh ${SPINNAKER_VM} -- -L 9000:localhost:9000 -L8080:$(basename $JENKINS_VM):8080
+        gcloud compute ssh ${SPINNAKER_VM} -- -L 8081:localhost:8081 -L8080:$(basename $JENKINS_VM):8080
 
 1. After a few minutes, you can access the Spinnaker and Jenkins UIs respectively by visiting the following web address:
 
-        http://localhost:9000
+        http://localhost:8081
         http://localhost:8080
 
 ## Teardown

--- a/config/spinnaker-local.yml
+++ b/config/spinnaker-local.yml
@@ -257,6 +257,7 @@ services:
     # If you are proxying Spinnaker behind a single host, you may want to
     # override these values. Remember to run `reconfigure_spinnaker.sh` after.
     #baseUrl: http://spinnaker.mydomain.com
+    port: 8081
     gateUrl: ${services.deck.baseUrl}/gate
     #bakeryUrl: ${services.deck.baseUrl}/rosco
     auth:

--- a/scripts/jenkins.sh
+++ b/scripts/jenkins.sh
@@ -32,7 +32,7 @@ JENKINS_VERSION=1.658
 JENKINS_DEB=jenkins_${JENKINS_VERSION}_all.deb
 apt-get update
 apt-get install -y wget default-jre-headless iptables-persistent daemon nginx
-wget http://pkg.jenkins-ci.org/debian/binary/${JENKINS_DEB}
+wget https://storage.googleapis.com/solutions-public-assets/jenkins-cd/${JENKINS_DEB}
 dpkg -i ${JENKINS_DEB}
 
 usermod -a -G shadow jenkins
@@ -128,28 +128,8 @@ cat > /var/lib/jenkins/jobs/runSpinnakerScript/config.xml <<EOF
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>REGION_PARAM</name>
-          <description>The region the Spinnaker deployment is running against</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>ENV_PARAM</name>
           <description>Environment Spinnaker is running against</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>CLUSTER_PARAM</name>
-          <description>The cluster Spinnaker is deploying to</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>CMC</name>
-          <description>The CMC this deployment is associated with</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>CONTEXT</name>
-          <description>The parameters available to this task</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>

--- a/scripts/jenkins.sh
+++ b/scripts/jenkins.sh
@@ -81,7 +81,7 @@ EOF
 # Install initial plugins
 JENKINS_PLUGIN_DIR=/var/lib/jenkins/plugins
 mkdir -p ${JENKINS_PLUGIN_DIR}
-PLUGINS="structs/1.6/structs.hpi workflow-step-api/1.14.2/workflow-step-api.hpi workflow-scm-step/1.14.2/workflow-scm-step.hpi git-client/2.4.1/git-client.hpi scm-api/2.1.1/scm-api.hpi git/3.2.0/git.hpi"
+PLUGINS="structs/1.6/structs.hpi workflow-step-api/1.14.2/workflow-step-api.hpi workflow-scm-step/1.14.2/workflow-scm-step.hpi git-client/2.4.1/git-client.hpi scm-api/2.1.1/scm-api.hpi git/3.2.0/git.hpi google-source-plugin/0.3/google-source-plugin.hpi google-metadata-plugin/0.2/google-metadata-plugin.hpi oauth-credentials/0.3/oauth-credentials.hpi google-oauth-plugin/0.4/google-oauth-plugin.hpi"
 JENKINS_PLUGIN_URL="http://updates.jenkins-ci.org/download/plugins"
 for p in ${PLUGINS}; do
   curl --retry 3 --retry-delay 5 -sSL -f ${JENKINS_PLUGIN_URL}/${p} -o ${JENKINS_PLUGIN_DIR}/$(basename ${p})
@@ -137,6 +137,11 @@ cat > /var/lib/jenkins/jobs/runSpinnakerScript/config.xml <<EOF
           <description>git repository url.</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REPO_BRANCH</name>
+          <description>git repository branch.</description>
+          <defaultValue>master</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -150,7 +155,7 @@ cat > /var/lib/jenkins/jobs/runSpinnakerScript/config.xml <<EOF
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>master</name>
+        <name>\$REPO_BRANCH</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>

--- a/scripts/spinnaker.sh
+++ b/scripts/spinnaker.sh
@@ -59,7 +59,11 @@ apt-get install -y openjdk-8-jdk unzip \
 
 # Configure Web Server for Gate
 echo "Listen 0.0.0.0:8081" >> /etc/apache2/ports.conf
-sed -i 's#VirtualHost 127.0.0.1:9000#VirtualHost 0.0.0.0:8081#g' /etc/apache2/sites-enabled/spinnaker.conf
+sed -i \
+  -e 's#VirtualHost 127.0.0.1:9000#VirtualHost 0.0.0.0:8081#g' \
+  -e '$i\\n  <Location "/gate">\n    Header set Content-Type "application/json; charset=utf-8" \n  </Location>' \
+    /etc/apache2/sites-enabled/spinnaker.conf
+a2enmod headers
 service apache2 restart
 
 # Install Packer

--- a/scripts/spinnaker.sh
+++ b/scripts/spinnaker.sh
@@ -58,8 +58,8 @@ apt-get install -y openjdk-8-jdk unzip \
                    spinnaker=${SPINNAKER_VERSION}
 
 # Configure Web Server for Gate
-echo "Listen 0.0.0.0:9000" >> /etc/apache2/ports.conf
-sed -i 's#VirtualHost 127.0.0.1:9000#VirtualHost 0.0.0.0:9000#g' /etc/apache2/sites-enabled/spinnaker.conf
+echo "Listen 0.0.0.0:8081" >> /etc/apache2/ports.conf
+sed -i 's#VirtualHost 127.0.0.1:9000#VirtualHost 0.0.0.0:8081#g' /etc/apache2/sites-enabled/spinnaker.conf
 service apache2 restart
 
 # Install Packer

--- a/scripts/spinnaker.sh
+++ b/scripts/spinnaker.sh
@@ -62,7 +62,18 @@ echo "Listen 0.0.0.0:8081" >> /etc/apache2/ports.conf
 sed -i \
   -e 's#VirtualHost 127.0.0.1:9000#VirtualHost 0.0.0.0:8081#g' \
   -e '$i\\n  <Location "/gate">\n    Header set Content-Type "application/json; charset=utf-8" \n  </Location>' \
-    /etc/apache2/sites-enabled/spinnaker.conf
+    /etc/apache2/sites-available/spinnaker.conf
+
+# Configure web server proxy for Jenkins
+echo "Listen 0.0.0.0:8082" >> /etc/apache2/ports.conf
+cat > /etc/apache2/sites-available/jenkins.conf <<EOF
+<VirtualHost 0.0.0.0:8082>
+  ProxyPass "/" "http://${JENKINS_IP}:8080/" retry=0
+  ProxyPassReverse "/" "http://${JENKINS_IP}:8080/"
+</VirtualHost>
+EOF
+ln -sf /etc/apache2/sites-available/jenkins.conf /etc/apache2/sites-enabled/jenkins.conf
+
 a2enmod headers
 service apache2 restart
 
@@ -82,7 +93,7 @@ SPINNAKER_GOOGLE_DEFAULT_REGION=$REGION
 SPINNAKER_GOOGLE_DEFAULT_ZONE=$ZONE
 
 SPINNAKER_JENKINS_ENABLED=true
-SPINNAKER_JENKINS_BASEURL=http://$JENKINS_IP/
+SPINNAKER_JENKINS_BASEURL=http://localhost:8082/
 SPINNAKER_JENKINS_USER=jenkins
 SPINNAKER_JENKINS_PASSWORD=$JENKINS_PASSWORD
 

--- a/templates/jenkins.jinja
+++ b/templates/jenkins.jinja
@@ -16,6 +16,7 @@ resources:
 - name: {{ env["deployment"] }}-jenkins-hc
   type: compute.v1.httpHealthCheck
   properties:
+    checkIntervalSec: 30
     port: 80
     requestPath: /login
 - name: {{ env["deployment"] }}-jenkins-ig

--- a/templates/network.jinja
+++ b/templates/network.jinja
@@ -78,7 +78,7 @@ resources:
     network: $(ref.{{ env["deployment"] }}-spinnaker-network.selfLink)
     allowed:
     - IPProtocol: tcp
-      ports: ["9000"]
+      ports: ["8081"]
     sourceRanges:
     - "130.211.0.0/22"
     targetTags:
@@ -114,7 +114,7 @@ resources:
 - type: compute.v1.backendService
   name: {{ env["deployment"] }}-spinnaker-api-backend
   properties:
-    port: 9000
+    port: 8081
     portName: "api"
     backends:
       - name: spinnaker-api

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -16,7 +16,7 @@ resources:
 - name: {{ env["deployment"] }}-spinnaker-hc
   type: compute.v1.httpHealthCheck
   properties:
-    port: 9000
+    port: 8081
 - name: {{ env["deployment"] }}-spinnaker-ig
   type: compute.beta.instanceGroupManager
   properties:

--- a/templates/spinnaker.jinja.schema
+++ b/templates/spinnaker.jinja.schema
@@ -29,11 +29,11 @@ properties:
   clouddriverVersion:
     type: string
     description: "Version of clouddriver"
-    default: "1.600.0"
+    default: "1.603.0"
   deckVersion:
     type: string
     description: "Version of deck"
-    default: "2.1083.0"
+    default: "2.1086.0"
   echoVersion:
     type: string
     description: "Version of echo"
@@ -45,15 +45,15 @@ properties:
   gateVersion:
     type: string
     description: "Version of gate"
-    default: "3.29.0"
+    default: "3.30.0"
   igorVersion:
     type: string
     description: "Version of igor"
-    default: "1.65.0"
+    default: "1.67.0"
   orcaVersion:
     type: string
     description: "Version of orca"
-    default: "1.398.0"
+    default: "1.400.0"
   roscoVersion:
     type: string
     description: "Version of rosco"
@@ -61,4 +61,4 @@ properties:
   spinnakerVersion:
     type: string
     description: "Version of spinnaker"
-    default: "0.79.0"
+    default: "0.80.0"

--- a/templates/spinnaker.jinja.schema
+++ b/templates/spinnaker.jinja.schema
@@ -29,11 +29,11 @@ properties:
   clouddriverVersion:
     type: string
     description: "Version of clouddriver"
-    default: "1.590.0"
+    default: "1.600.0"
   deckVersion:
     type: string
     description: "Version of deck"
-    default: "2.1071.0"
+    default: "2.1083.0"
   echoVersion:
     type: string
     description: "Version of echo"
@@ -45,7 +45,7 @@ properties:
   gateVersion:
     type: string
     description: "Version of gate"
-    default: "3.28.0"
+    default: "3.29.0"
   igorVersion:
     type: string
     description: "Version of igor"
@@ -53,7 +53,7 @@ properties:
   orcaVersion:
     type: string
     description: "Version of orca"
-    default: "1.387.0"
+    default: "1.398.0"
   roscoVersion:
     type: string
     description: "Version of rosco"


### PR DESCRIPTION
The Web Preview feature of Cloud Shell only lets you tunnel ports 8080-8084. The Spinnaker UI was running on port 9000, and when the UI would hit the `/gate/credentials` endpoint, it would redirect back to the `${services.deck.gateUrl}` spinnaker config value which was set to `http://localhost:9000` and the UI would break.

Switching the port to 8081 lets the redirect pass through a working port for the web preview proxy.

Also added the `Content-Type: application/json` header to all `/gate` responses via apache config. This is done because the Cloud Shell web preview proxy does some content-type detection and breaks Deck for several of the gate API calls. 

This PR also upgrades the spinnaker components to the latest versions.