### PR TITLE
Update deprecated gcloud flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ a pipeline.
         export GOOGLE_PROJECT=$(gcloud config get-value project)
         export DEPLOYMENT_NAME="${USER}-test1"
         export JENKINS_PASSWORD=$(openssl rand -base64 15)
-        gcloud deployment-manager deployments create --config config.jinja ${DEPLOYMENT_NAME} --properties jenkinsPassword:${JENKINS_PASSWORD}
+        gcloud deployment-manager deployments create --template config.jinja ${DEPLOYMENT_NAME} --properties jenkinsPassword:${JENKINS_PASSWORD}
 
 1. Once instance provisioning is complete get the name of your Spinnaker and Jenkins instances by
    running:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ a pipeline.
 1. Once instance provisioning is complete get the name of your Spinnaker and Jenkins instances by
    running:
 
-        export SPINNAKER_VM=$(gcloud compute instances list --regexp "${DEPLOYMENT_NAME}-spinnaker.+" --uri)
-        export JENKINS_VM=$(gcloud compute instances list --regexp "${DEPLOYMENT_NAME}-jenkins.+" --uri)
+        export SPINNAKER_VM=$(gcloud compute instances list --filter="name~'${DEPLOYMENT_NAME}-spinnaker.+'" --uri)
+        export JENKINS_VM=$(gcloud compute instances list --filter="name~'${DEPLOYMENT_NAME}-jenkins.+'" --uri)
 
 1. Creating an SSH tunnel to your Spinnaker instance as follows:
 


### PR DESCRIPTION
--config and --regexp flags are deprecated, and replaced by --template and --filter respectively.