### PR TITLE
Upgrade base images, install kubectl, disable autoDelete

### DIFF
--- a/scripts/spinnaker.sh
+++ b/scripts/spinnaker.sh
@@ -43,6 +43,8 @@ curl -sSO https://repo.stackdriver.com/stack-install.sh
 bash stack-install.sh --write-gcm
 
 echo "deb https://dl.bintray.com/spinnaker/debians trusty spinnaker" > /etc/apt/sources.list.d/spinnaker.list
+echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+curl -s -f "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
 curl -s -f "https://bintray.com/user/downloadSubjectPublicKey?username=spinnaker" | apt-key add -
 add-apt-repository -y ppa:openjdk-r/ppa
 apt-get update
@@ -55,7 +57,8 @@ apt-get install -y openjdk-8-jdk unzip \
                    spinnaker-igor=${IGOR_VERSION} \
                    spinnaker-orca=${ORCA_VERSION} \
                    spinnaker-rosco=${ROSCO_VERSION} \
-                   spinnaker=${SPINNAKER_VERSION}
+                   spinnaker=${SPINNAKER_VERSION} \
+                   kubectl
 
 # Configure Web Server for Gate
 echo "Listen 0.0.0.0:8081" >> /etc/apache2/ports.conf

--- a/templates/jenkins.jinja
+++ b/templates/jenkins.jinja
@@ -54,7 +54,7 @@ resources:
             type: ONE_TO_ONE_NAT
           networkIP: {{ properties["jenkinsIP"] }}
         disks:
-        - autoDelete: true
+        - autoDelete: false
           boot: true
           deviceName: jenkins-vm-tmpl-boot-disk
           initializeParams:

--- a/templates/redis.jinja
+++ b/templates/redis.jinja
@@ -48,7 +48,7 @@ resources:
           boot: true
           autoDelete: true
           initializeParams:
-            sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1404-lts
+            sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
         metadata:
           items:
           - key: startup-script

--- a/templates/redis.jinja
+++ b/templates/redis.jinja
@@ -46,7 +46,7 @@ resources:
         - deviceName: boot
           type: PERSISTENT
           boot: true
-          autoDelete: true
+          autoDelete: false
           initializeParams:
             sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
         metadata:

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -59,7 +59,7 @@ resources:
         - deviceName: boot
           type: PERSISTENT
           boot: true
-          autoDelete: true
+          autoDelete: false
           diskType: pd-ssd
           diskSizeGb: 256
           initializeParams:

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -63,7 +63,7 @@ resources:
           diskType: pd-ssd
           diskSizeGb: 256
           initializeParams:
-            sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1404-lts
+            sourceImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
         metadata:
           items:
           - key: deployment


### PR DESCRIPTION
This pull request contains three patches, all relatively minor:

* Upgrade base images to the current 1604-LTS, which is the current LTS Ubuntu release.
* Install kubectl package in Spinnaker instance. It is useful for debugging kubernetes authentication issues.
* Disable autoDelete option for persistent disks. It causes the instance to reset to the default state on each restart.