### PR TITLE
Cloudshell fix and version update

### DIFF
--- a/config/gce-ansible.json
+++ b/config/gce-ansible.json
@@ -35,7 +35,7 @@
      "type": "shell",
      "inline": ["sudo apt-add-repository -y ppa:ansible/ansible",
                 "sudo apt-get update",
-                "sudo apt-get install -y ansible=2.3.0.0-1ppa~xenial git=1:2.7.4-0ubuntu1",
+                "sudo apt-get install -y git ansible=$(apt-cache madison ansible | cut -d '|' -f2 | grep ppa | tr -d '[:space:]')",
                 "sudo git clone {{user `repository`}} /opt/go/src/deploy",
                 "cd /opt/go/src/deploy && sudo git checkout {{user `repository_hash`}}",
                 "sudo ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook -i 'localhost,' bake.yml"]

--- a/config/spinnaker-local.yml
+++ b/config/spinnaker-local.yml
@@ -258,7 +258,7 @@ services:
     # override these values. Remember to run `reconfigure_spinnaker.sh` after.
     #baseUrl: http://spinnaker.mydomain.com
     port: 8081
-    gateUrl: ${services.deck.baseUrl}/gate
+    gateUrl: /gate
     #bakeryUrl: ${services.deck.baseUrl}/rosco
     auth:
       enabled: false

--- a/templates/spinnaker.jinja
+++ b/templates/spinnaker.jinja
@@ -26,7 +26,7 @@ resources:
     zone: {{ properties["zone"] }}
     autoHealingPolicies:
     - healthCheck: $(ref.{{ env["deployment"] }}-spinnaker-hc.selfLink)
-      initialDelaySec: 300
+      initialDelaySec: 600
 - name: spinnaker-{{ env["project"] }}-{{ env["deployment"] }}
   type: storage.v1.bucket
   properties:

--- a/templates/spinnaker.jinja.schema
+++ b/templates/spinnaker.jinja.schema
@@ -22,43 +22,45 @@ imports:
 - path: spinnaker.jinja
 
 properties:
+  # Checking for new versions of spinnaker components:
+  #   apt-cache madison spinnaker-COMPONENT | cut -d '|' -f2 |sort --version-sort | tail -1
   packerVersion:
     type: string
     description: "Version of packer"
-    default: "1.0.0"
+    default: "1.1.3"
   clouddriverVersion:
     type: string
     description: "Version of clouddriver"
-    default: "1.603.0"
+    default: "1.748.1"
   deckVersion:
     type: string
     description: "Version of deck"
-    default: "2.1086.0"
+    default: "2.1160.0"
   echoVersion:
     type: string
     description: "Version of echo"
-    default: "1.132.0"
+    default: "1.154.0"
   front50Version:
     type: string
     description: "Version of front50"
-    default: "1.90.0"
+    default: "1.99.0"
   gateVersion:
     type: string
     description: "Version of gate"
-    default: "3.30.0"
+    default: "4.9.2"
   igorVersion:
     type: string
     description: "Version of igor"
-    default: "1.67.0"
+    default: "1.83.1"
   orcaVersion:
     type: string
     description: "Version of orca"
-    default: "1.400.0"
+    default: "5.3.1"
   roscoVersion:
     type: string
     description: "Version of rosco"
-    default: "0.93.0"
+    default: "0.99.0"
   spinnakerVersion:
     type: string
     description: "Version of spinnaker"
-    default: "0.80.0"
+    default: "0.82.0"

--- a/templates/spinnaker.jinja.schema
+++ b/templates/spinnaker.jinja.schema
@@ -39,7 +39,7 @@ properties:
   echoVersion:
     type: string
     description: "Version of echo"
-    default: "1.154.0"
+    default: "1.153.0"
   front50Version:
     type: string
     description: "Version of front50"


### PR DESCRIPTION
- Fix to gateUrl when proxying through cloudshell webpreview
- Updated components to latest version
- Increased healthcheck grace period from 300 -> 600 seconds to give spinnaker instance more time to install components.